### PR TITLE
Add --skipBuild flag

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -19,6 +19,7 @@ interface InitOptions {
 	prettier?: boolean;
 	vscode?: boolean;
 	packageManager?: PackageManager;
+	skipBuild?: boolean;
 }
 
 enum InitMode {
@@ -371,7 +372,9 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 		await fs.copy(templateDir, cwd);
 	});
 
-	await benchmark("Compiling..", () => cmd("npm run build", cwd));
+	if (!argv.skipBuild) {
+		await benchmark("Compiling..", () => cmd(selectedPackageManager.build, cwd));
+	}
 }
 
 const GAME_DESCRIPTION = "Generate a Roblox place";
@@ -427,6 +430,10 @@ export = {
 			.option("packageManager", {
 				choices: Object.values(PackageManager),
 				describe: "Choose an alternative package manager",
+			})
+			.option("skipBuild", {
+				boolean: true,
+				describe: "Do not run build script",
 			})
 
 			.command([InitMode.Game, InitMode.Place], GAME_DESCRIPTION, {}, argv => init(argv as never, InitMode.Game))

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -391,6 +391,14 @@ export = {
 				string: true,
 				describe: "roblox-ts compiler version",
 			})
+			.check(argv => {
+				if (argv.compilerVersion !== undefined && !/^\d+\.\d+\.\d+$/.test(argv.compilerVersion)) {
+					throw new InitError(
+						"Invalid --compilerVersion. You must specify a version in the form of X.X.X. (i.e. --compilerVersion 1.2.3)",
+					);
+				}
+				return true;
+			}, true)
 			.option("dir", {
 				string: true,
 				describe: "Project directory",
@@ -420,14 +428,6 @@ export = {
 				choices: Object.values(PackageManager),
 				describe: "Choose an alternative package manager",
 			})
-			.check(argv => {
-				if (argv.compilerVersion !== undefined && !/^\d+\.\d+\.\d+$/.test(argv.compilerVersion)) {
-					throw new InitError(
-						"Invalid --compilerVersion. You must specify a version in the form of X.X.X. (i.e. --compilerVersion 1.2.3)",
-					);
-				}
-				return true;
-			}, true)
 
 			.command([InitMode.Game, InitMode.Place], GAME_DESCRIPTION, {}, argv => init(argv as never, InitMode.Game))
 			.command(InitMode.Model, MODEL_DESCRIPTION, {}, argv => init(argv as never, InitMode.Model))


### PR DESCRIPTION
- and hoist --compilerVersion `.check()` to be near --compilerVersion `.option()`

Will be useful for roblox-ts compiler workflow which runs `create-roblox-ts`. It will:
1. Run with `--skipBuild`
2. Install local repo as roblox-ts dependency in template project
3. `npm run build`