### PR TITLE
init: migrate ESLint to flat config and assorted improvements

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -312,10 +312,13 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 				"\t{",
 				"\t\textends: [roblox.configs.recommended, ...typescript.configs.recommendedTypeChecked],",
 				'\t\tfiles: ["src/**/*.ts", "src/**/*.tsx"],',
+				"\t\trules: {",
+				'\t\t\t"@typescript-eslint/only-throw-error": "off",',
 			];
 			if (prettier) {
-				stream.push("\t\trules: {", '\t\t\t"prettier/prettier": "warn",', "\t\t},");
+				stream.push('\t\t\t"prettier/prettier": "warn",');
 			}
+			stream.push("\t\t},");
 			stream.push("\t},");
 			stream.push("]);");
 			await fs.outputFile(paths.eslintrc, stream.filter(str => str !== undefined).join("\n"));

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -198,7 +198,7 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 		packageLockJson: path.join(cwd, "package-lock.json"),
 		tsconfig: path.join(cwd, "tsconfig.json"),
 		gitignore: path.join(cwd, ".gitignore"),
-		eslintrc: path.join(cwd, ".eslintrc"),
+		eslintrc: path.join(cwd, "eslint.config.ts"),
 		prettierrc: path.join(cwd, ".prettierrc"),
 		settings: path.join(cwd, ".vscode", "settings.json"),
 		extensions: path.join(cwd, ".vscode", "extensions.json"),
@@ -282,10 +282,12 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 
 		if (eslint) {
 			devDependencies.push(
+				"@eslint/eslintrc",
+				"@eslint/js",
+				"typescript-eslint",
 				"eslint",
-				"@typescript-eslint/eslint-plugin",
-				"@typescript-eslint/parser",
 				"eslint-plugin-roblox-ts",
+				"jiti",
 			);
 			if (prettier) {
 				devDependencies.push("eslint-config-prettier", "eslint-plugin-prettier");
@@ -297,32 +299,27 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 
 	if (eslint) {
 		await benchmark("Configuring ESLint..", async () => {
-			const eslintConfig = {
-				parser: "@typescript-eslint/parser",
-				parserOptions: {
-					jsx: true,
-					useJSXTextNode: true,
-					ecmaVersion: 2018,
-					sourceType: "module",
-					project: "./tsconfig.json",
-				},
-				ignorePatterns: ["/out"],
-				plugins: ["@typescript-eslint", "roblox-ts"],
-				extends: [
-					"eslint:recommended",
-					"plugin:@typescript-eslint/recommended",
-					"plugin:roblox-ts/recommended-legacy",
-				],
-				rules: {} as { [index: string]: unknown },
-			};
-
+			const stream: Array<string | undefined> = [
+				'import roblox from "eslint-plugin-roblox-ts";',
+				'import typescript from "typescript-eslint";',
+				'import { defineConfig, globalIgnores } from "eslint/config";',
+				prettier ? 'import prettierRecommended from "eslint-plugin-prettier/recommended";' : undefined,
+				"",
+				"export default defineConfig([",
+				'\tglobalIgnores(["out/"]),',
+				prettier ? "\tprettierRecommended," : undefined,
+				"\ttypescript.configs.recommendedTypeChecked,",
+				"\troblox.parser,",
+				"\t{",
+				"\t\textends: [roblox.configs.recommended],",
+				'\t\tfiles: ["src/**/*.ts", "src/**/*.tsx"],',
+			];
 			if (prettier) {
-				eslintConfig.plugins.push("prettier");
-				eslintConfig.extends.push("plugin:prettier/recommended");
-				eslintConfig.rules["prettier/prettier"] = "warn";
+				stream.push("\t\trules: {", '\t\t\t"prettier/prettier": "warn",', "\t\t},");
 			}
-
-			await fs.outputFile(paths.eslintrc, JSON.stringify(eslintConfig, undefined, "\t"));
+			stream.push("\t},");
+			stream.push("]);");
+			await fs.outputFile(paths.eslintrc, stream.filter(str => str !== undefined).join("\n"));
 		});
 	}
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -308,10 +308,9 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 				"export default defineConfig([",
 				'\tglobalIgnores(["out/"]),',
 				prettier ? "\tprettierRecommended," : undefined,
-				"\ttypescript.configs.recommendedTypeChecked,",
 				"\troblox.parser,",
 				"\t{",
-				"\t\textends: [roblox.configs.recommended],",
+				"\t\textends: [roblox.configs.recommended, ...typescript.configs.recommendedTypeChecked],",
 				'\t\tfiles: ["src/**/*.ts", "src/**/*.tsx"],',
 			];
 			if (prettier) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -235,6 +235,14 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 			build: "rbxtsc",
 			watch: "rbxtsc -w",
 		};
+		// append lint/formatting commands if specified
+		if (prettier) {
+			pkgJson.scripts["format"] = "prettier --write .";
+			pkgJson.scripts["format:check"] = "prettier .";
+		}
+		if (eslint) {
+			pkgJson.scripts["lint"] = "eslint";
+		}
 		if (template === InitMode.Package) {
 			pkgJson.name = RBXTS_SCOPE + "/" + pkgJson.name;
 			pkgJson.main = "out/init.lua";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -341,7 +341,7 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 				recommendations: ["roblox-ts.vscode-roblox-ts"],
 			};
 			const settings = {
-				"typescript.tsdk": "node_modules/typescript/lib",
+				"js/ts.tsdk.path": "node_modules/typescript/lib",
 				"files.eol": "\n",
 			};
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -113,13 +113,19 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 		await Promise.allSettled(["npm", "pnpm", "yarn", "git"].map(v => lookpath(v)))
 	).map(v => (v.status === "fulfilled" ? v.value !== undefined : true));
 
-	const packageManagerExistance: { [K in PackageManager]: boolean } = {
+	const packageManagerExistence: { [K in PackageManager]: boolean } = {
 		[PackageManager.NPM]: npmAvailable,
 		[PackageManager.PNPM]: pnpmAvailable,
 		[PackageManager.Yarn]: yarnAvailable,
 	};
 
-	const packageManagerCount = Object.values(packageManagerExistance).filter(exists => exists).length;
+	const defaultPackageManager = pnpmAvailable
+		? PackageManager.PNPM
+		: yarnAvailable
+			? PackageManager.Yarn
+			: PackageManager.NPM;
+
+	const packageManagerCount = Object.values(packageManagerExistence).filter(exists => exists).length;
 
 	const {
 		template = initMode,
@@ -127,7 +133,7 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 		eslint = argv.eslint ?? argv.yes ?? false,
 		prettier = argv.prettier ?? argv.yes ?? false,
 		vscode = argv.vscode ?? argv.yes ?? false,
-		packageManager = argv.packageManager ?? PackageManager.NPM,
+		packageManager = argv.packageManager ?? defaultPackageManager,
 	}: {
 		template: InitMode;
 		git: boolean;
@@ -177,7 +183,7 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 				name: "packageManager",
 				message: "Multiple package managers detected. Select package manager:",
 				choices: Object.entries(PackageManager)
-					.filter(([, packageManager]) => packageManagerExistance[packageManager])
+					.filter(([, packageManager]) => packageManagerExistence[packageManager])
 					.map(([managerDisplayName, managerEnum]) => ({
 						title: managerDisplayName,
 						value: managerEnum,

--- a/templates/game/default.project.json
+++ b/templates/game/default.project.json
@@ -1,9 +1,6 @@
 {
 	"name": "roblox-ts-game",
-	"globIgnorePaths": [
-		"**/package.json",
-		"**/tsconfig.json"
-	],
+	"globIgnorePaths": ["**/package.json", "**/tsconfig.json"],
 	"tree": {
 		"$className": "DataModel",
 		"ServerScriptService": {

--- a/templates/game/tsconfig.json
+++ b/templates/game/tsconfig.json
@@ -23,5 +23,6 @@
 		"baseUrl": "src",
 		"incremental": true,
 		"tsBuildInfoFile": "out/tsconfig.tsbuildinfo"
-	}
+	},
+	"exclude": ["out", "node_modules", "eslint.config.ts"]
 }

--- a/templates/game/tsconfig.json
+++ b/templates/game/tsconfig.json
@@ -18,6 +18,7 @@
 		"typeRoots": ["node_modules/@rbxts"],
 
 		// configurable
+		"types": ["types"],
 		"rootDir": "src",
 		"outDir": "out",
 		"baseUrl": "src",

--- a/templates/model/default.project.json
+++ b/templates/model/default.project.json
@@ -1,9 +1,6 @@
 {
 	"name": "roblox-ts-model",
-	"globIgnorePaths": [
-		"**/package.json",
-		"**/tsconfig.json"
-	],
+	"globIgnorePaths": ["**/package.json", "**/tsconfig.json"],
 	"tree": {
 		"$path": "out",
 		"include": {

--- a/templates/model/tsconfig.json
+++ b/templates/model/tsconfig.json
@@ -23,5 +23,6 @@
 		"baseUrl": "src",
 		"incremental": true,
 		"tsBuildInfoFile": "out/tsconfig.tsbuildinfo"
-	}
+	},
+	"exclude": ["out", "node_modules", "eslint.config.ts"]
 }

--- a/templates/model/tsconfig.json
+++ b/templates/model/tsconfig.json
@@ -18,6 +18,7 @@
 		"typeRoots": ["node_modules/@rbxts"],
 
 		// configurable
+		"types": ["types"],
 		"rootDir": "src",
 		"outDir": "out",
 		"baseUrl": "src",

--- a/templates/package/tsconfig.json
+++ b/templates/package/tsconfig.json
@@ -18,6 +18,7 @@
 		"typeRoots": ["node_modules/@rbxts"],
 
 		// configurable
+		"types": ["types"],
 		"rootDir": "src",
 		"outDir": "out",
 		"incremental": true,

--- a/templates/package/tsconfig.json
+++ b/templates/package/tsconfig.json
@@ -23,5 +23,6 @@
 		"incremental": true,
 		"tsBuildInfoFile": "out/tsconfig.tsbuildinfo",
 		"declaration": true
-	}
+	},
+	"exclude": ["out", "node_modules", "eslint.config.ts"]
 }

--- a/templates/plugin/default.project.json
+++ b/templates/plugin/default.project.json
@@ -1,9 +1,6 @@
 {
 	"name": "roblox-ts-plugin",
-	"globIgnorePaths": [
-		"**/package.json",
-		"**/tsconfig.json"
-	],
+	"globIgnorePaths": ["**/package.json", "**/tsconfig.json"],
 	"tree": {
 		"$path": "out",
 		"include": {

--- a/templates/plugin/serve.project.json
+++ b/templates/plugin/serve.project.json
@@ -1,9 +1,6 @@
 {
 	"name": "roblox-ts-plugin-serve",
-	"globIgnorePaths": [
-		"**/package.json",
-		"**/tsconfig.json"
-	],
+	"globIgnorePaths": ["**/package.json", "**/tsconfig.json"],
 	"tree": {
 		"$className": "DataModel",
 		"ServerScriptService": {

--- a/templates/plugin/tsconfig.json
+++ b/templates/plugin/tsconfig.json
@@ -24,5 +24,6 @@
 		"baseUrl": "src",
 		"incremental": true,
 		"tsBuildInfoFile": "out/tsconfig.tsbuildinfo"
-	}
+	},
+	"exclude": ["out", "node_modules", "eslint.config.ts"]
 }


### PR DESCRIPTION
`create-roblox-ts` is due for an upgrade with its dev tooling packages including ESLint. This PR migrates the legacy ESLint configs to use flat configs and updated the dev dependencies.

Also some bug fixes with handling the case where the user only has 1 package manager, in which the old case would default to NPM even if the user *doesn't* have NPM. Now, it picks the appropriate package manager.

(This replaces #22, which I closed by accident. Same scope, minus unrelated changes.)

Summary of everything changed:
- Generate ESLint flat config (`eslint.config.ts`) using the unified `typescript-eslint` package and `recommendedTypeChecked`, replacing the legacy `.eslintrc` JSON. Templates' tsconfigs gain `"exclude": [..., "eslint.config.ts"]` so the new TS config file isn't picked up by `tsc`.
- Disable `@typescript-eslint/only-throw-error` in the generated config — in roblox-ts, `throw` compiles to Lua's `error()` which accepts any value, so throwing strings is idiomatic and shouldn't be flagged.
- Add `format` / `format:check` (when prettier is enabled) and `lint` (when eslint is enabled) scripts to the generated `package.json`.
- Add `"types": ["types"]` to the game/model/package tsconfig templates so `@rbxts/types` is loaded — without this, type-aware ESLint rules (`no-unsafe-call`, etc.) treat Roblox globals like `print`/`warn` as `any`.
- Fix the package-manager fallback so users with only pnpm/yarn installed don't get `npm init` invoked when the multi-PM prompt is skipped. Also fixes the `packageManagerExistance` typo.
- Use the modern `js/ts.tsdk.path` key in generated VSCode workspace settings (replaces the older `typescript.tsdk`).
- Apply prettier formatting to template `*.project.json` files (style-only).